### PR TITLE
Optimize Log2FloorNonZero with Lzcnt (.NET Core 3.0) intrinsic

### DIFF
--- a/BrotliSharpLib/BrotliSharpLib.csproj
+++ b/BrotliSharpLib/BrotliSharpLib.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net20;net35;net40;net45;net451;net452;net462;netstandard1.3;netstandard1.6;netstandard2.0;netcoreapp1.0;netcoreapp1.1</TargetFrameworks>
+		<TargetFrameworks>net20;net35;net40;net45;net451;net452;net462;netstandard1.3;netstandard1.6;netstandard2.0;netcoreapp1.0;netcoreapp1.1;netcoreapp3.0</TargetFrameworks>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<NoWarn>1570;1701</NoWarn>

--- a/BrotliSharpLib/Encode/FastLog.cs
+++ b/BrotliSharpLib/Encode/FastLog.cs
@@ -112,8 +112,7 @@ namespace BrotliSharpLib {
 #endif
         private static uint Log2FloorNonZero(size_t n) {
 #if NETCOREAPP3_0
-            if (System.Runtime.Intrinsics.X86.Lzcnt.IsSupported)
-            {
+            if (System.Runtime.Intrinsics.X86.Lzcnt.IsSupported) {
                 return 31u ^ (uint)System.Runtime.Intrinsics.X86.Lzcnt.LeadingZeroCount((uint)n | 1);
             }
 #endif

--- a/BrotliSharpLib/Encode/FastLog.cs
+++ b/BrotliSharpLib/Encode/FastLog.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using size_t = BrotliSharpLib.Brotli.SizeT;
 
 namespace BrotliSharpLib {
@@ -106,7 +107,16 @@ namespace BrotliSharpLib {
             return Math.Log(v) * LOG_2_INV;
         }
 
+#if AGGRESSIVE_INLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         private static uint Log2FloorNonZero(size_t n) {
+#if NETCOREAPP3_0
+            if (System.Runtime.Intrinsics.X86.Lzcnt.IsSupported)
+            {
+                return 31u ^ (uint)System.Runtime.Intrinsics.X86.Lzcnt.LeadingZeroCount((uint)n | 1);
+            }
+#endif
             size_t m = n;
             uint result = 0;
             while ((m >>= 1) != 0) result++;


### PR DESCRIPTION
Tested on a 2mb txt file.
Compressing, level=11:
before: **0.95sec**
after:       **0.83sec**
^ netcoreapp3.0
net462: **1.23sec**

For reference, .NET Core's BrotliStream (with native lib inside): **0.48sec**

Found this bottle neck via dotTrace:
![image](https://user-images.githubusercontent.com/523221/50399984-538fd480-0794-11e9-8847-a1cfe5fc24e3.png)

PS: original impl also uses it - https://github.com/google/brotli/blob/ee2a5e1540cbd6ef883a897499d9596307f7f7f9/c/enc/fast_log.h#L25