### PR TITLE
Add span-based single compression and decompression methods

### DIFF
--- a/BrotliSharpLib.Tests/BrotliSharpLib.Tests.csproj
+++ b/BrotliSharpLib.Tests/BrotliSharpLib.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/BrotliSharpLib/BrotliSharpLib.csproj
+++ b/BrotliSharpLib/BrotliSharpLib.csproj
@@ -6,8 +6,8 @@
 		<NoWarn>1570;1701</NoWarn>
 	</PropertyGroup>
 	<PropertyGroup>
-		<Version>0.3.3</Version>
-		<FileVersion>0.3.3</FileVersion>
+		<Version>0.3.4</Version>
+		<FileVersion>0.3.4</FileVersion>
 		<Authors>master131</Authors>
 		<Description>Full C# port of Brotli compression library.</Description>
 		<Copyright>Copyright (c) 2017-2019 master131</Copyright>
@@ -15,7 +15,7 @@
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>brotli;csharp;net</PackageTags>
-		<AssemblyVersion>0.3.2</AssemblyVersion>
+		<AssemblyVersion>0.3.4</AssemblyVersion>
 		<PackageLicenseUrl>https://github.com/master131/BrotliSharpLib/blob/master/LICENSE</PackageLicenseUrl>
 		<PackageProjectUrl>https://github.com/master131/BrotliSharpLib</PackageProjectUrl>
 		<SignAssembly>true</SignAssembly>
@@ -29,37 +29,55 @@
 	<PropertyGroup Condition="'$(TargetFramework)'!='net20' AND '$(TargetFramework)'!='net35' AND '$(TargetFramework)'!='net40' AND '$(TargetFramework)'!='net45' AND '$(TargetFramework)'!='netstandard1.1'">
 		<DefineConstants>$(DefineConstants);SIZE_OF_T</DefineConstants>
 	</PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'!='net20' AND '$(TargetFramework)'!='net35' AND '$(TargetFramework)'!='net40'">
+    <DefineConstants>$(DefineConstants);HAS_SPAN</DefineConstants>
+  </PropertyGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+	  <PackageReference Include="System.Memory">
+	    <Version>4.5.4</Version>
+	  </PackageReference>
 	  <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-	    <Version>4.5.2</Version>
+	    <Version>4.5.3</Version>
 	  </PackageReference>
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+	  <PackageReference Include="System.Memory">
+	    <Version>4.5.4</Version>
+	  </PackageReference>
 	  <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-	    <Version>4.5.2</Version>
+	    <Version>4.5.3</Version>
 	  </PackageReference>
 	</ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
+    <PackageReference Include="System.Memory">
+      <Version>4.5.4</Version>
+    </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-      <Version>4.5.2</Version>
+      <Version>4.5.3</Version>
     </PackageReference>
     <PackageReference Include="System.IO.Compression">
       <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+	  <PackageReference Include="System.Memory">
+	    <Version>4.5.4</Version>
+	  </PackageReference>
 	  <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-	    <Version>4.5.2</Version>
+	    <Version>4.5.3</Version>
 	  </PackageReference>
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+	  <PackageReference Include="System.Memory">
+	    <Version>4.5.4</Version>
+	  </PackageReference>
 	  <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-	    <Version>4.5.2</Version>
+	    <Version>4.5.3</Version>
 	  </PackageReference>
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
 	  <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-	    <Version>4.5.2</Version>
+	    <Version>4.5.3</Version>
 	  </PackageReference>
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
This PR adds `Try{C,Dec}ompressBuffer` methods which take spans, and perform a single round of de/compression targeting the buffers, with an API similar to the new BCL APIs [BrotliEncoder.TryCompress](https://docs.microsoft.com/en-us/dotnet/api/system.io.compression.brotliencoder.trycompress?view=net-5.0) and [BrotliDecoder.TryDecompress](https://docs.microsoft.com/en-us/dotnet/api/system.io.compression.brotlidecoder.trydecompress?view=net-5.0).